### PR TITLE
(library) Output: add prefix/suffix delimiters and Writable impl for f64

### DIFF
--- a/algo_lib/src/io/output.rs
+++ b/algo_lib/src/io/output.rs
@@ -47,7 +47,9 @@ pub struct Output<'s> {
     at: usize,
     bool_output: BoolOutput,
     precision: Option<usize>,
+    prefix: Option<u8>,
     separator: u8,
+    suffix: Option<u8>,
 }
 
 impl<'s> Output<'s> {
@@ -62,7 +64,9 @@ impl<'s> Output<'s> {
             at: 0,
             bool_output: BoolOutput::YesNoCaps,
             precision: None,
+            prefix: None,
             separator: b' ',
+            suffix: None,
         }
     }
 }
@@ -127,6 +131,9 @@ impl Output<'_> {
     }
 
     pub fn print_iter<T: Writable, I: Iterator<Item = T>>(&mut self, iter: I) {
+        if let Some(p) = self.prefix {
+            self.put(p);
+        }
         let mut first = true;
         for e in iter {
             if first {
@@ -135,6 +142,9 @@ impl Output<'_> {
                 self.put(self.separator);
             }
             e.write(self);
+        }
+        if let Some(s) = self.suffix {
+            self.put(s);
         }
     }
 
@@ -167,6 +177,12 @@ impl Output<'_> {
     }
     pub fn set_separator(&mut self, separator: u8) {
         self.separator = separator;
+    }
+    pub fn set_prefix(&mut self, prefix: u8) {
+        self.prefix = Some(prefix);
+    }
+    pub fn set_suffix(&mut self, suffix: u8) {
+        self.suffix = Some(suffix);
     }
 }
 

--- a/algo_lib/src/io/output.rs
+++ b/algo_lib/src/io/output.rs
@@ -261,6 +261,15 @@ impl<T: Writable> Writable for Vec<T> {
     }
 }
 
+impl Writable for f64 {
+    fn write(&self, output: &mut Output) {
+        match output.precision {
+            Some(p) => write!(output, "{:.*}", p, self).unwrap(),
+            None => write!(output, "{}", self).unwrap(),
+        }
+    }
+}
+
 impl Writable for () {
     fn write(&self, _output: &mut Output) {}
 }


### PR DESCRIPTION
Hello, I have a [repo](https://github.com/omar-s-ta/rust-solver) based on the `example-contests-workspace` and I came across this repo couple of days ago. I'm adding couple of stuff that I found useful and thought might be useful here too.

Thanks in advance.

## Summary

  Two small additive enhancements to `algo_lib/src/io/output.rs`.

  ### 1. Optional prefix/suffix bytes for `print_iter`

New fields `prefix: Option<u8>` and `suffix: Option<u8>`, controlled by `set_prefix(b)` / `set_suffix(b)`.
Useful for printing things like `[1, 2, 3]` or `{1 2 3}` without manually bracketing every call site:

  ```rust
  out.set_prefix(b'[');
  out.set_suffix(b']');
  out.set_separator(b',');
  out.print_line(&vec![1, 2, 3]);  // [1,2,3]
  ```

Defaults to `None` on both sides, so existing output is unchanged.

  ### 2. `Writable` impl for `f64` (when `Real` is not used)

  Direct `Writable for f64` that respects the existing `precision` setting:

  ```rust
  impl Writable for f64 {
      fn write(&self, output: &mut Output) {
          match output.precision {
              Some(p) => write!(output, "{:.*}", p, self).unwrap(),
              None    => write!(output, "{}", self).unwrap(),
          }
      }
  }
  ```

Lets you `out.print_line(3.14_f64)` without going through `Real.set_precision(k)` already exists in `Output`; this just hooks `f64` into it. No new dependencies.