### PR TITLE
IncDec: add in-place inc_mut/dec_mut and collapse impls into recursive blankets

### DIFF
--- a/algo_lib/src/collections/vec_ext/inc_dec.rs
+++ b/algo_lib/src/collections/vec_ext/inc_dec.rs
@@ -37,28 +37,33 @@ impl<T: IncDec> IncDec for Vec<T> {
     }
 }
 
-impl<U: IncDec, V: IncDec> IncDec for (U, V) {
-    fn inc_mut(&mut self) {
-        self.0.inc_mut();
-        self.1.inc_mut();
-    }
+/// Implements [`IncDec`] for tuples treated as records: the **first two fields
+/// are coordinates** and are shifted, while any remaining fields are an
+/// untouched payload (edge capacity, cost, char, weight, …).
+///
+/// Only `.0` and `.1` are inc/dec'd; fields from `.2` onward are left as-is and
+/// carry **no** `IncDec`/numeric bound — so `(usize, usize, char)` and
+/// `(usize, usize, i64)` both work, and payloads are never corrupted.
+///
+/// Do not extend this to recurse into every field: decrementing a flow capacity
+/// or cost is a silent bug, and it would reject valid non-numeric payloads.
+macro_rules! tuple_inc_dec_impl {
+    ($U: tt $V: tt $($tail: tt)*) => {
+        impl<$U: IncDec, $V: IncDec, $($tail,)*> IncDec for ($U, $V, $($tail,)*) {
+            fn inc_mut(&mut self) {
+                self.0.inc_mut();
+                self.1.inc_mut();
+            }
 
-    fn dec_mut(&mut self) {
-        self.0.dec_mut();
-        self.1.dec_mut();
-    }
+            fn dec_mut(&mut self) {
+                self.0.dec_mut();
+                self.1.dec_mut();
+            }
+        }
+    };
 }
 
-impl<T: IncDec, U: IncDec, V: IncDec> IncDec for (T, U, V) {
-    fn inc_mut(&mut self) {
-        self.0.inc_mut();
-        self.1.inc_mut();
-        self.2.inc_mut();
-    }
-
-    fn dec_mut(&mut self) {
-        self.0.dec_mut();
-        self.1.dec_mut();
-        self.2.dec_mut();
-    }
-}
+tuple_inc_dec_impl!(U V);
+tuple_inc_dec_impl!(T U V);
+tuple_inc_dec_impl!(T U V W);
+tuple_inc_dec_impl!(T U V W X);

--- a/algo_lib/src/collections/vec_ext/inc_dec.rs
+++ b/algo_lib/src/collections/vec_ext/inc_dec.rs
@@ -1,134 +1,64 @@
 use crate::numbers::num_traits::algebra::{AdditionMonoidWithSub, One};
 
-pub trait IncDec {
+pub trait IncDec: Sized {
+    fn inc_mut(&mut self);
+    fn dec_mut(&mut self);
+
     #[must_use]
-    fn inc(self) -> Self;
+    fn inc(mut self) -> Self {
+        self.inc_mut();
+        self
+    }
+
     #[must_use]
-    fn dec(self) -> Self;
+    fn dec(mut self) -> Self {
+        self.dec_mut();
+        self
+    }
 }
 
 impl<T: AdditionMonoidWithSub + One> IncDec for T {
-    fn inc(self) -> Self {
-        self + T::one()
+    fn inc_mut(&mut self) {
+        *self += T::one()
     }
 
-    fn dec(self) -> Self {
-        self - T::one()
-    }
-}
-
-impl<T: AdditionMonoidWithSub + One> IncDec for Vec<T> {
-    fn inc(mut self) -> Self {
-        self.iter_mut().for_each(|i| *i += T::one());
-        self
-    }
-
-    fn dec(mut self) -> Self {
-        self.iter_mut().for_each(|i| *i -= T::one());
-        self
+    fn dec_mut(&mut self) {
+        *self -= T::one()
     }
 }
 
-impl<T: AdditionMonoidWithSub + One> IncDec for Vec<Vec<T>> {
-    fn inc(mut self) -> Self {
-        self.iter_mut()
-            .for_each(|v| v.iter_mut().for_each(|i| *i += T::one()));
-        self
+impl<T: IncDec> IncDec for Vec<T> {
+    fn inc_mut(&mut self) {
+        self.iter_mut().for_each(T::inc_mut);
     }
 
-    fn dec(mut self) -> Self {
-        self.iter_mut()
-            .for_each(|v| v.iter_mut().for_each(|i| *i -= T::one()));
-        self
+    fn dec_mut(&mut self) {
+        self.iter_mut().for_each(T::dec_mut);
     }
 }
 
-impl<T: AdditionMonoidWithSub + One, U: AdditionMonoidWithSub + One> IncDec for Vec<(T, U)> {
-    fn inc(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j)| {
-            *i += T::one();
-            *j += U::one();
-        });
-        self
+impl<U: IncDec, V: IncDec> IncDec for (U, V) {
+    fn inc_mut(&mut self) {
+        self.0.inc_mut();
+        self.1.inc_mut();
     }
 
-    fn dec(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j)| {
-            *i -= T::one();
-            *j -= U::one();
-        });
-        self
+    fn dec_mut(&mut self) {
+        self.0.dec_mut();
+        self.1.dec_mut();
     }
 }
 
-impl<T: AdditionMonoidWithSub + One, U: AdditionMonoidWithSub + One, V> IncDec for Vec<(T, U, V)> {
-    fn inc(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, _)| {
-            *i += T::one();
-            *j += U::one();
-        });
-        self
+impl<T: IncDec, U: IncDec, V: IncDec> IncDec for (T, U, V) {
+    fn inc_mut(&mut self) {
+        self.0.inc_mut();
+        self.1.inc_mut();
+        self.2.inc_mut();
     }
 
-    fn dec(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, _)| {
-            *i -= T::one();
-            *j -= U::one();
-        });
-        self
-    }
-}
-
-impl<T: AdditionMonoidWithSub + One, U: AdditionMonoidWithSub + One, V, W> IncDec
-    for Vec<(T, U, V, W)>
-{
-    fn inc(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, ..)| {
-            *i += T::one();
-            *j += U::one();
-        });
-        self
-    }
-
-    fn dec(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, ..)| {
-            *i -= T::one();
-            *j -= U::one();
-        });
-        self
-    }
-}
-
-impl<T: AdditionMonoidWithSub + One, U: AdditionMonoidWithSub + One, V, W, X> IncDec
-    for Vec<(T, U, V, W, X)>
-{
-    fn inc(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, ..)| {
-            *i += T::one();
-            *j += U::one();
-        });
-        self
-    }
-
-    fn dec(mut self) -> Self {
-        self.iter_mut().for_each(|(i, j, ..)| {
-            *i -= T::one();
-            *j -= U::one();
-        });
-        self
-    }
-}
-
-impl<T: AdditionMonoidWithSub + One, U: AdditionMonoidWithSub + One> IncDec for (T, U) {
-    fn inc(mut self) -> Self {
-        self.0 += T::one();
-        self.1 += U::one();
-        self
-    }
-
-    fn dec(mut self) -> Self {
-        self.0 -= T::one();
-        self.1 -= U::one();
-        self
+    fn dec_mut(&mut self) {
+        self.0.dec_mut();
+        self.1.dec_mut();
+        self.2.dec_mut();
     }
 }


### PR DESCRIPTION
Reworks the `IncDec` trait to be in-place-first and recursive, replacing the hand-written per-shape implementations with a small set of composable blanket impls.

- Adds `inc_mut(&mut self)` / `dec_mut(&mut self)` as the trait's core operations. The existing `inc(self)` / `dec(self)` become provided methods implemented on top of them, so callers keep the same by-value API while in-place mutation is now available for free.
- Replaces the numeric base impl with `inc_mut`/`dec_mut` bodies.
- Collapses the six concrete collection/tuple impls (`Vec<T>`, `Vec<Vec<T>>`, `Vec<(T, U)>`, `Vec<(T, U, V)>`, `Vec<(T, U, V, W)>`, `Vec<(T, U, V, W, X)>`, `(T, U)`) into:
  - a single recursive `impl<T: IncDec> IncDec for Vec<T>`, and
  - generic tuple impls `impl IncDec for (U, V)` and `(T, U, V)`.

Because the impls are now recursive over `IncDec` rather than `AdditionMonoidWithSub + One`, nested shapes compose automatically: `Vec<Vec<T>>`, `Vec<(T, U)>`, `Vec<(T, U, V)>`, etc. all work without dedicated impls.